### PR TITLE
feat: add comments command with diff context

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "bun-types": "^1.2.20",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.5",
+        "msw": "^2.10.5",
         "oxlint": "^1.12.0",
         "react-devtools-core": "^6.1.5",
         "typescript": "^5.9.2",
@@ -68,6 +69,12 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg=="],
 
+    "@bundled-es-modules/cookie": ["@bundled-es-modules/cookie@2.0.1", "", { "dependencies": { "cookie": "^0.7.2" } }, "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw=="],
+
+    "@bundled-es-modules/statuses": ["@bundled-es-modules/statuses@1.0.1", "", { "dependencies": { "statuses": "^2.0.1" } }, "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg=="],
+
+    "@bundled-es-modules/tough-cookie": ["@bundled-es-modules/tough-cookie@0.1.6", "", { "dependencies": { "@types/tough-cookie": "^4.0.5", "tough-cookie": "^4.1.4" } }, "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw=="],
+
     "@effect/cluster": ["@effect/cluster@0.46.4", "", { "peerDependencies": { "@effect/platform": "^0.90.0", "@effect/rpc": "^0.68.3", "@effect/sql": "^0.44.1", "@effect/workflow": "^0.8.3", "effect": "^3.17.6" } }, "sha512-81nWw5ABtRZZFmQTrWvfsUnqTg9LybIFYvmsiIL7xQ2t+g6746IZe9Tcv9bSmMdioJLgeuO4CiRg0FfDP2qCWA=="],
 
     "@effect/experimental": ["@effect/experimental@0.54.6", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.90.2", "effect": "^3.17.7", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-UqHMvCQmrZT6kUVoUC0lqyno4Yad+j9hBGCdUjW84zkLwAq08tPqySiZUKRwY+Ae5B2Ab8rISYJH7nQvct9DMQ=="],
@@ -85,6 +92,14 @@
     "@effect/sql": ["@effect/sql@0.44.2", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.54.6", "@effect/platform": "^0.90.4", "effect": "^3.17.7" } }, "sha512-DEcvriHvj88zu7keruH9NcHQzam7yQzLNLJO6ucDXMCAwWzYZSJOsmkxBznRFv8ylFtccSclKH2fuj+wRKPjCQ=="],
 
     "@effect/workflow": ["@effect/workflow@0.8.3", "", { "peerDependencies": { "@effect/platform": "^0.90.0", "@effect/rpc": "^0.68.3", "effect": "^3.17.6" } }, "sha512-8X5IOemCb6I66GMd84w6NSmaQ+Ya3oXwItCUMelQAEuRtGzwqsw8PNNunQgK/poSRkmpszlsKOb6kEVNjSdFiQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.16", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag=="],
+
+    "@inquirer/core": ["@inquirer/core@10.2.0", "", { "dependencies": { "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.13", "", {}, "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.8", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -105,6 +120,14 @@
     "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+
+    "@mswjs/interceptors": ["@mswjs/interceptors@0.39.6", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw=="],
+
+    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
+
+    "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qL0zqIYdYrXl6ghTIHnhJkvyYy1eKz0P8YIEp59MjY3/zNiyk/gtyp8LkwZdqb9ezbcX9UDQhSuSO1wURJsq8g=="],
 
@@ -164,9 +187,15 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
     "@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow=="],
 
     "@types/react": ["@types/react@19.1.11", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ=="],
+
+    "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
 
@@ -208,6 +237,8 @@
 
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
     "cliui": ["cliui@4.1.0", "", { "dependencies": { "string-width": "^2.1.1", "strip-ansi": "^4.0.0", "wrap-ansi": "^2.0.0" } }, "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ=="],
 
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
@@ -225,6 +256,8 @@
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
 
@@ -261,6 +294,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-toolkit": ["es-toolkit@1.39.10", "", {}, "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -300,6 +335,8 @@
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
+    "graphql": ["graphql@16.11.0", "", {}, "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="],
+
     "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
@@ -309,6 +346,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
@@ -335,6 +374,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -384,7 +425,11 @@
 
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
+    "msw": ["msw@2.10.5", "", { "dependencies": { "@bundled-es-modules/cookie": "^2.0.1", "@bundled-es-modules/statuses": "^1.0.1", "@bundled-es-modules/tough-cookie": "^0.1.6", "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.39.1", "@open-draft/deferred-promise": "^2.2.0", "@open-draft/until": "^2.1.0", "@types/cookie": "^0.6.0", "@types/statuses": "^2.0.4", "graphql": "^16.8.1", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "strict-event-emitter": "^0.5.1", "type-fest": "^4.26.1", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A=="],
+
     "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
+    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
     "nano-spawn": ["nano-spawn@1.0.2", "", {}, "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg=="],
 
@@ -408,6 +453,8 @@
 
     "os-locale": ["os-locale@2.1.0", "", { "dependencies": { "execa": "^0.7.0", "lcid": "^1.0.0", "mem": "^1.1.0" } }, "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA=="],
 
+    "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
+
     "oxlint": ["oxlint@1.12.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.12.0", "@oxlint/darwin-x64": "1.12.0", "@oxlint/linux-arm64-gnu": "1.12.0", "@oxlint/linux-arm64-musl": "1.12.0", "@oxlint/linux-x64-gnu": "1.12.0", "@oxlint/linux-x64-musl": "1.12.0", "@oxlint/win32-arm64": "1.12.0", "@oxlint/win32-x64": "1.12.0", "oxlint-tsgolint": ">=0.0.1" }, "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-tBQ9aB00aYLlGXE21WJHnKQAI8xoi2V6Eiz/WvGV7FwU9YLYuNOurEEVbfoS5u0ODX8GLvGWj1fdHh5Rb74Kkw=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.0.4", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.0.4", "@oxlint-tsgolint/darwin-x64": "0.0.4", "@oxlint-tsgolint/linux-arm64": "0.0.4", "@oxlint-tsgolint/linux-x64": "0.0.4", "@oxlint-tsgolint/win32-arm64": "0.0.4", "@oxlint-tsgolint/win32-x64": "0.0.4" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-KFWVP+VU3ymgK/Dtuf6iRkqjo+aN42lS1YThY6JWlNi1GQqm7wtio/kAwssqDhm8kP+CVXbgZAtu1wgsK4XeTg=="],
@@ -430,6 +477,8 @@
 
     "path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
     "path-type": ["path-type@3.0.0", "", { "dependencies": { "pify": "^3.0.0" } }, "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -442,7 +491,13 @@
 
     "pseudomap": ["pseudomap@1.0.2", "", {}, "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="],
 
+    "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
     "react": ["react@19.1.1", "", {}, "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="],
 
@@ -455,6 +510,8 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-main-filename": ["require-main-filename@1.0.1", "", {}, "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="],
+
+    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
@@ -482,6 +539,10 @@
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
+
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
@@ -494,6 +555,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
@@ -501,6 +564,10 @@
     "undici": ["undici@7.15.0", "", {}, "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
+    "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+
+    "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
@@ -526,6 +593,8 @@
 
     "yargs-parser": ["yargs-parser@8.1.0", "", { "dependencies": { "camelcase": "^4.1.0" } }, "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ=="],
 
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "@babel/code-frame/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
@@ -538,6 +607,12 @@
 
     "@effect/platform-node-shared/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
+    "@inquirer/core/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
+
+    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
     "cliui/string-width": ["string-width@2.1.1", "", { "dependencies": { "is-fullwidth-code-point": "^2.0.0", "strip-ansi": "^4.0.0" } }, "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="],
@@ -549,6 +624,8 @@
     "ink/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "msw/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "node-gyp-build-optional-packages/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
@@ -566,6 +643,14 @@
 
     "@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "@inquirer/core/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
@@ -578,9 +663,27 @@
 
     "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "msw/yargs/get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "msw/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "msw/yargs/y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "msw/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@4.0.0", "", { "dependencies": { "ansi-regex": "^3.0.0" } }, "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@inquirer/core/wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cliui/wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@1.0.0", "", { "dependencies": { "number-is-nan": "^1.0.0" } }, "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw=="],
 
@@ -590,6 +693,28 @@
 
     "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "msw/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "msw/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "msw/yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "msw/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "msw/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "msw/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "msw/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "msw/yargs/cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "msw/yargs/cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bun-types": "^1.2.20",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "msw": "^2.10.5",
     "oxlint": "^1.12.0",
     "react-devtools-core": "^6.1.5",
     "typescript": "^5.9.2"

--- a/src/cli/commands/abandon.ts
+++ b/src/cli/commands/abandon.ts
@@ -63,7 +63,7 @@ const abandonSingleChange = (changeId: string, options: AbandonOptions): Effect.
     }
   })
 
-export const abandonCommand = (changeId?: string, options: AbandonOptions = {}): Effect.Effect<void, any, GerritApiService> =>
+export const abandonCommand = (changeId?: string, options: AbandonOptions = {}): Effect.Effect<void, ApiError, GerritApiService> =>
   Effect.gen(function* () {
     const gerritApi = yield* GerritApiService
     

--- a/src/cli/commands/abandon.ts
+++ b/src/cli/commands/abandon.ts
@@ -37,28 +37,24 @@ const abandonSingleChange = (changeId: string, options: AbandonOptions): Effect.
           console.log(`  Message: ${options.message}`)
         }
       }
-    } catch (error) {
+    } catch {
       // If we can't get change details, still try to abandon with just the ID
-      try {
-        yield* gerritApi.abandonChange(changeId, options.message)
-        
-        if (options.xml) {
-          console.log(`<?xml version="1.0" encoding="UTF-8"?>`)
-          console.log(`<abandon_result>`)
-          console.log(`  <status>success</status>`)
-          console.log(`  <change_id>${changeId}</change_id>`)
-          if (options.message) {
-            console.log(`  <message><![CDATA[${options.message}]]></message>`)
-          }
-          console.log(`</abandon_result>`)
-        } else {
-          console.log(`✓ Abandoned change ${changeId}`)
-          if (options.message) {
-            console.log(`  Message: ${options.message}`)
-          }
+      yield* gerritApi.abandonChange(changeId, options.message)
+      
+      if (options.xml) {
+        console.log(`<?xml version="1.0" encoding="UTF-8"?>`)
+        console.log(`<abandon_result>`)
+        console.log(`  <status>success</status>`)
+        console.log(`  <change_id>${changeId}</change_id>`)
+        if (options.message) {
+          console.log(`  <message><![CDATA[${options.message}]]></message>`)
         }
-      } catch (abandonError) {
-        throw abandonError
+        console.log(`</abandon_result>`)
+      } else {
+        console.log(`✓ Abandoned change ${changeId}`)
+        if (options.message) {
+          console.log(`  Message: ${options.message}`)
+        }
       }
     }
   })

--- a/src/cli/commands/comment.ts
+++ b/src/cli/commands/comment.ts
@@ -1,5 +1,5 @@
 import { Effect, pipe } from 'effect'
-import { GerritApiService } from '@/api/gerrit'
+import { ApiError, GerritApiService } from '@/api/gerrit'
 import type { ReviewInput } from '@/schemas/gerrit'
 
 interface CommentOptions {
@@ -10,7 +10,7 @@ interface CommentOptions {
 export const commentCommand = (
   changeId: string,
   options: CommentOptions,
-): Effect.Effect<void, any, GerritApiService> =>
+): Effect.Effect<void, ApiError | Error, GerritApiService> =>
   Effect.gen(function* () {
     const message = options.message
 

--- a/src/cli/commands/comment.ts
+++ b/src/cli/commands/comment.ts
@@ -1,4 +1,4 @@
-import { Effect, pipe } from 'effect'
+import { Effect } from 'effect'
 import { ApiError, GerritApiService } from '@/api/gerrit'
 import type { ReviewInput } from '@/schemas/gerrit'
 

--- a/src/cli/commands/comments.ts
+++ b/src/cli/commands/comments.ts
@@ -1,0 +1,263 @@
+import { Effect } from 'effect'
+import { ApiError, GerritApiService } from '@/api/gerrit'
+import type { CommentInfo } from '@/schemas/gerrit'
+import { formatDate, colors } from '@/utils/formatters'
+
+interface CommentsOptions {
+  xml?: boolean
+}
+
+interface CommentWithContext {
+  comment: CommentInfo
+  context?: {
+    before: string[]
+    line?: string
+    after: string[]
+  }
+}
+
+const getCommentsForChange = (
+  changeId: string
+): Effect.Effect<CommentInfo[], ApiError, GerritApiService> =>
+  Effect.gen(function* () {
+    const gerritApi = yield* GerritApiService
+    // Get all comments for the change
+    const comments = yield* gerritApi.getComments(changeId)
+    
+    // Flatten all comments from all files
+    const allComments: CommentInfo[] = []
+    for (const [path, fileComments] of Object.entries(comments)) {
+      for (const comment of fileComments) {
+        allComments.push({
+          ...comment,
+          path: path === '/COMMIT_MSG' ? 'Commit Message' : path
+        })
+      }
+    }
+    
+    // Sort by path and then by line number
+    allComments.sort((a, b) => {
+      const pathCompare = (a.path || '').localeCompare(b.path || '')
+      if (pathCompare !== 0) return pathCompare
+      return (a.line || 0) - (b.line || 0)
+    })
+    
+    return allComments
+  })
+
+const getDiffContext = (
+  changeId: string,
+  path: string,
+  line?: number
+): Effect.Effect<{ before: string[], line?: string, after: string[] }, ApiError, GerritApiService> =>
+  Effect.gen(function* () {
+    if (!line || path === 'Commit Message') {
+      return { before: [], after: [] }
+    }
+    
+    const gerritApi = yield* GerritApiService
+    try {
+      // Get the file diff
+      const diff = yield* gerritApi.getFileDiff(changeId, path)
+      
+      // Extract context around the line
+      let currentLine = 0
+      const contextBefore: string[] = []
+      const contextAfter: string[] = []
+      let targetLine: string | undefined
+      let foundLine = false
+      
+      for (const section of diff.content) {
+        if (section.ab) {
+          for (const l of section.ab) {
+            currentLine++
+            if (currentLine === line - 2) contextBefore.push(l)
+            else if (currentLine === line - 1) contextBefore.push(l)
+            else if (currentLine === line) {
+              targetLine = l
+              foundLine = true
+            }
+            else if (currentLine === line + 1) contextAfter.push(l)
+            else if (currentLine === line + 2) contextAfter.push(l)
+          }
+        }
+        if (section.b) {
+          for (const l of section.b) {
+            currentLine++
+            if (currentLine === line - 2) contextBefore.push(l)
+            else if (currentLine === line - 1) contextBefore.push(l)
+            else if (currentLine === line) {
+              targetLine = l
+              foundLine = true
+            }
+            else if (currentLine === line + 1) contextAfter.push(l)
+            else if (currentLine === line + 2) contextAfter.push(l)
+          }
+        }
+        if (foundLine && contextAfter.length >= 2) break
+      }
+      
+      return { before: contextBefore, line: targetLine, after: contextAfter }
+    } catch {
+      // If we can't get the diff, just return empty context
+      return { before: [], after: [] }
+    }
+  })
+
+const formatCommentsPretty = (comments: CommentWithContext[]): void => {
+  if (comments.length === 0) {
+    console.log('No comments found on this change')
+    return
+  }
+  
+  console.log(`Found ${comments.length} comment${comments.length === 1 ? '' : 's'}:\n`)
+  
+  let currentPath: string | undefined
+  
+  for (const { comment, context } of comments) {
+    // Group by file
+    if (comment.path !== currentPath) {
+      currentPath = comment.path
+      console.log(`${colors.blue}═══ ${currentPath} ═══${colors.reset}`)
+    }
+    
+    // Comment metadata
+    const author = comment.author?.name || 'Unknown'
+    const date = comment.updated ? formatDate(comment.updated) : ''
+    const status = comment.unresolved ? `${colors.yellow}[UNRESOLVED]${colors.reset} ` : ''
+    
+    console.log(`\n${status}${colors.dim}${author} • ${date}${colors.reset}`)
+    
+    if (comment.line) {
+      console.log(`${colors.dim}Line ${comment.line}:${colors.reset}`)
+      
+      // Show context if available
+      if (context && (context.before.length > 0 || context.line || context.after.length > 0)) {
+        console.log(`${colors.dim}───────────────────${colors.reset}`)
+        for (const line of context.before) {
+          console.log(`${colors.dim}  ${line}${colors.reset}`)
+        }
+        if (context.line) {
+          console.log(`${colors.green}> ${context.line}${colors.reset}`)
+        }
+        for (const line of context.after) {
+          console.log(`${colors.dim}  ${line}${colors.reset}`)
+        }
+        console.log(`${colors.dim}───────────────────${colors.reset}`)
+      }
+    }
+    
+    // Comment message (indent each line)
+    const messageLines = comment.message.split('\n')
+    for (const line of messageLines) {
+      console.log(`  ${line}`)
+    }
+  }
+}
+
+const formatCommentsXml = (changeId: string, comments: CommentWithContext[]): void => {
+  console.log(`<?xml version="1.0" encoding="UTF-8"?>`)
+  console.log(`<comments_result>`)
+  console.log(`  <change_id>${changeId}</change_id>`)
+  console.log(`  <comment_count>${comments.length}</comment_count>`)
+  console.log(`  <comments>`)
+  
+  for (const { comment, context } of comments) {
+    console.log(`    <comment>`)
+    console.log(`      <id>${comment.id}</id>`)
+    if (comment.path) {
+      console.log(`      <path><![CDATA[${comment.path}]]></path>`)
+    }
+    if (comment.line) {
+      console.log(`      <line>${comment.line}</line>`)
+    }
+    if (comment.range) {
+      console.log(`      <range>`)
+      console.log(`        <start_line>${comment.range.start_line}</start_line>`)
+      console.log(`        <end_line>${comment.range.end_line}</end_line>`)
+      if (comment.range.start_character !== undefined) {
+        console.log(`        <start_character>${comment.range.start_character}</start_character>`)
+      }
+      if (comment.range.end_character !== undefined) {
+        console.log(`        <end_character>${comment.range.end_character}</end_character>`)
+      }
+      console.log(`      </range>`)
+    }
+    if (comment.author) {
+      console.log(`      <author>`)
+      if (comment.author.name) {
+        console.log(`        <name><![CDATA[${comment.author.name}]]></name>`)
+      }
+      if (comment.author.email) {
+        console.log(`        <email>${comment.author.email}</email>`)
+      }
+      if (comment.author._account_id !== undefined) {
+        console.log(`        <account_id>${comment.author._account_id}</account_id>`)
+      }
+      console.log(`      </author>`)
+    }
+    if (comment.updated) {
+      console.log(`      <updated>${comment.updated}</updated>`)
+    }
+    if (comment.unresolved !== undefined) {
+      console.log(`      <unresolved>${comment.unresolved}</unresolved>`)
+    }
+    if (comment.in_reply_to) {
+      console.log(`      <in_reply_to>${comment.in_reply_to}</in_reply_to>`)
+    }
+    console.log(`      <message><![CDATA[${comment.message}]]></message>`)
+    
+    if (context && (context.before.length > 0 || context.line || context.after.length > 0)) {
+      console.log(`      <diff_context>`)
+      if (context.before.length > 0) {
+        console.log(`        <before>`)
+        for (const line of context.before) {
+          console.log(`          <line><![CDATA[${line}]]></line>`)
+        }
+        console.log(`        </before>`)
+      }
+      if (context.line) {
+        console.log(`        <target_line><![CDATA[${context.line}]]></target_line>`)
+      }
+      if (context.after.length > 0) {
+        console.log(`        <after>`)
+        for (const line of context.after) {
+          console.log(`          <line><![CDATA[${line}]]></line>`)
+        }
+        console.log(`        </after>`)
+      }
+      console.log(`      </diff_context>`)
+    }
+    
+    console.log(`    </comment>`)
+  }
+  
+  console.log(`  </comments>`)
+  console.log(`</comments_result>`)
+}
+
+export const commentsCommand = (
+  changeId: string,
+  options: CommentsOptions
+): Effect.Effect<void, ApiError | Error, GerritApiService> =>
+  Effect.gen(function* () {
+    // Get all comments
+    const comments = yield* getCommentsForChange(changeId)
+    
+    // Get context for each comment
+    const commentsWithContext: CommentWithContext[] = []
+    for (const comment of comments) {
+      const context = comment.path && comment.line
+        ? yield* getDiffContext(changeId, comment.path, comment.line)
+        : undefined
+      
+      commentsWithContext.push({ comment, context })
+    }
+    
+    // Format output
+    if (options.xml) {
+      formatCommentsXml(changeId, commentsWithContext)
+    } else {
+      formatCommentsPretty(commentsWithContext)
+    }
+  })

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { GerritApiService } from '@/api/gerrit'
+import { ApiError, GerritApiService } from '@/api/gerrit'
 import type { DiffOptions } from '@/schemas/gerrit'
 
 interface DiffCommandOptions {
@@ -12,7 +12,7 @@ interface DiffCommandOptions {
 export const diffCommand = (
   changeId: string,
   options: DiffCommandOptions,
-): Effect.Effect<void, any, GerritApiService> =>
+): Effect.Effect<void, ApiError | Error, GerritApiService> =>
   Effect.gen(function* () {
     const apiService = yield* GerritApiService
     

--- a/src/cli/commands/mine.ts
+++ b/src/cli/commands/mine.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { GerritApiService } from '@/api/gerrit'
+import { ApiError, GerritApiService } from '@/api/gerrit'
 import type { ChangeInfo } from '@/schemas/gerrit'
 import { formatDate, getStatusIndicator, colors } from '@/utils/formatters'
 
@@ -9,7 +9,7 @@ interface MineOptions {
 
 // ANSI color codes
 
-export const mineCommand = (options: MineOptions): Effect.Effect<void, any, GerritApiService> =>
+export const mineCommand = (options: MineOptions): Effect.Effect<void, ApiError, GerritApiService> =>
   Effect.gen(function* () {
     const gerritApi = yield* GerritApiService
     

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
-import { GerritApiService } from '@/api/gerrit'
-import { ConfigService } from '@/services/config'
+import { ApiError, GerritApiService } from '@/api/gerrit'
+import { ConfigError, ConfigService } from '@/services/config'
 import { execSync, spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -87,7 +87,7 @@ const getRepoRoot = (): string => {
   }
 }
 
-export const workspaceCommand = (changeSpec: string, options: WorkspaceOptions): Effect.Effect<void, any, GerritApiService | ConfigService> =>
+export const workspaceCommand = (changeSpec: string, options: WorkspaceOptions): Effect.Effect<void, ApiError | ConfigError | Error, GerritApiService | ConfigService> =>
   Effect.gen(function* () {
     // Check if we're in a git repo
     if (!isInGitRepo()) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { diffCommand } from './commands/diff'
 import { mineCommand } from './commands/mine'
 import { workspaceCommand } from './commands/workspace'
 import { abandonCommand } from './commands/abandon'
+import { commentsCommand } from './commands/comments'
 
 const program = new Command()
 
@@ -181,6 +182,32 @@ program
         console.log(`  <status>error</status>`)
         console.log(`  <error><![CDATA[${error instanceof Error ? error.message : String(error)}]]></error>`)
         console.log(`</abandon_result>`)
+      } else {
+        console.error('✗ Error:', error instanceof Error ? error.message : String(error))
+      }
+      process.exit(1)
+    }
+  })
+
+// comments command
+program
+  .command('comments <change-id>')
+  .description('Show all comments on a change with diff context')
+  .option('--xml', 'XML output for LLM consumption')
+  .action(async (changeId, options) => {
+    try {
+      const effect = commentsCommand(changeId, options).pipe(
+        Effect.provide(GerritApiServiceLive),
+        Effect.provide(ConfigServiceLive)
+      )
+      await Effect.runPromise(effect)
+    } catch (error) {
+      if (options.xml) {
+        console.log(`<?xml version="1.0" encoding="UTF-8"?>`)
+        console.log(`<comments_result>`)
+        console.log(`  <status>error</status>`)
+        console.log(`  <error><![CDATA[${error instanceof Error ? error.message : String(error)}]]></error>`)
+        console.log(`</comments_result>`)
       } else {
         console.error('✗ Error:', error instanceof Error ? error.message : String(error))
       }

--- a/src/schemas/gerrit.ts
+++ b/src/schemas/gerrit.ts
@@ -135,6 +135,48 @@ export const CommentInput: Schema.Schema<{
 })
 export type CommentInput = Schema.Schema.Type<typeof CommentInput>
 
+// Comment info returned from API
+export const CommentInfo: Schema.Schema<{
+  readonly id: string
+  readonly path?: string
+  readonly line?: number
+  readonly range?: {
+    readonly start_line: number
+    readonly end_line: number
+    readonly start_character?: number
+    readonly end_character?: number
+  }
+  readonly message: string
+  readonly author?: {
+    readonly name?: string
+    readonly email?: string
+    readonly _account_id?: number
+  }
+  readonly updated?: string
+  readonly unresolved?: boolean
+  readonly in_reply_to?: string
+}> = Schema.Struct({
+  id: Schema.String,
+  path: Schema.optional(Schema.String),
+  line: Schema.optional(Schema.Number),
+  range: Schema.optional(Schema.Struct({
+    start_line: Schema.Number,
+    end_line: Schema.Number,
+    start_character: Schema.optional(Schema.Number),
+    end_character: Schema.optional(Schema.Number),
+  })),
+  message: Schema.String,
+  author: Schema.optional(Schema.Struct({
+    name: Schema.optional(Schema.String),
+    email: Schema.optional(Schema.String),
+    _account_id: Schema.optional(Schema.Number),
+  })),
+  updated: Schema.optional(Schema.String),
+  unresolved: Schema.optional(Schema.Boolean),
+  in_reply_to: Schema.optional(Schema.String),
+})
+export type CommentInfo = Schema.Schema.Type<typeof CommentInfo>
+
 export const ReviewInput: Schema.Schema<{
   readonly message?: string
   readonly labels?: Record<string, number>

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, mock } from 'bun:test'
+import { Effect } from 'effect'
+import { commentsCommand } from '@/cli/commands/comments'
+import { GerritApiServiceLive } from '@/api/gerrit'
+import { ConfigService } from '@/services/config'
+import { Layer } from 'effect'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+import { commentHandlers, emptyCommentsHandlers } from './mocks/msw-handlers'
+
+// Create MSW server
+const server = setupServer(
+  // Default handler for auth check
+  http.get('*/a/accounts/self', ({ request }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth || !auth.startsWith('Basic ')) {
+      return HttpResponse.text('Unauthorized', { status: 401 })
+    }
+    return HttpResponse.json({ 
+      _account_id: 1000,
+      name: 'Test User',
+      email: 'test@example.com'
+    })
+  })
+)
+
+describe('comments command', () => {
+  let mockConsoleLog: ReturnType<typeof mock>
+  let mockConsoleError: ReturnType<typeof mock>
+
+  beforeAll(() => {
+    // Start MSW server before all tests
+    server.listen({ onUnhandledRequest: 'bypass' })
+  })
+
+  afterAll(() => {
+    // Clean up after all tests
+    server.close()
+  })
+
+  beforeEach(() => {
+    // Reset handlers to defaults before each test
+    server.resetHandlers()
+    
+    mockConsoleLog = mock(() => {})
+    mockConsoleError = mock(() => {})
+    console.log = mockConsoleLog
+    console.error = mockConsoleError
+  })
+
+  afterEach(() => {
+    // Clean up after each test
+    server.resetHandlers()
+  })
+
+  it('should fetch and display comments in pretty format', async () => {
+    // Add comment handlers for this test
+    server.use(...commentHandlers)
+    
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentsCommand('12345', {}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    // Check that comments were displayed
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('Found 3 comments')
+    expect(output).toContain('Commit Message')
+    expect(output).toContain('Please update the commit message')
+    expect(output).toContain('src/main.ts')
+    expect(output).toContain('Consider using a more descriptive variable name')
+    expect(output).toContain('[UNRESOLVED]')
+  })
+
+  it('should output XML format when --xml flag is used', async () => {
+    // Add comment handlers for this test
+    server.use(...commentHandlers)
+    
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentsCommand('12345', { xml: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    // Check XML output
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(output).toContain('<comments_result>')
+    expect(output).toContain('<change_id>12345</change_id>')
+    expect(output).toContain('<comment_count>3</comment_count>')
+    expect(output).toContain('<message><![CDATA[Please update the commit message]]></message>')
+    expect(output).toContain('<unresolved>true</unresolved>')
+    expect(output).toContain('</comments_result>')
+  })
+
+  it('should handle no comments gracefully', async () => {
+    // Use empty comments handlers for this test
+    server.use(...emptyCommentsHandlers)
+    
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentsCommand('12345', {}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('No comments found on this change')
+  })
+})

--- a/tests/mocks/msw-handlers.ts
+++ b/tests/mocks/msw-handlers.ts
@@ -3,7 +3,7 @@ import type { CommentInfo } from '@/schemas/gerrit'
 
 export const commentHandlers = [
   // Comments endpoint
-  http.get('*/a/changes/:changeId/revisions/:revisionId/comments', ({ params }) => {
+  http.get('*/a/changes/:changeId/revisions/:revisionId/comments', () => {
     const mockComments: Record<string, CommentInfo[]> = {
       '/COMMIT_MSG': [
         {

--- a/tests/mocks/msw-handlers.ts
+++ b/tests/mocks/msw-handlers.ts
@@ -1,0 +1,86 @@
+import { http, HttpResponse } from 'msw'
+import type { CommentInfo } from '@/schemas/gerrit'
+
+export const commentHandlers = [
+  // Comments endpoint
+  http.get('*/a/changes/:changeId/revisions/:revisionId/comments', ({ params }) => {
+    const mockComments: Record<string, CommentInfo[]> = {
+      '/COMMIT_MSG': [
+        {
+          id: 'comment1',
+          message: 'Please update the commit message',
+          author: {
+            name: 'Reviewer 1',
+            email: 'reviewer1@example.com',
+            _account_id: 1001,
+          },
+          updated: '2024-01-15 10:30:00.000000000',
+          unresolved: true,
+          line: 3,
+        },
+      ],
+      'src/main.ts': [
+        {
+          id: 'comment2',
+          message: 'Consider using a more descriptive variable name',
+          author: {
+            name: 'Reviewer 2',
+            email: 'reviewer2@example.com',
+            _account_id: 1002,
+          },
+          updated: '2024-01-15 11:45:00.000000000',
+          unresolved: false,
+          line: 42,
+        },
+        {
+          id: 'comment3',
+          message: 'This could be simplified',
+          author: {
+            name: 'Reviewer 1',
+            _account_id: 1001,
+          },
+          updated: '2024-01-15 12:00:00.000000000',
+          line: 67,
+        },
+      ],
+    }
+
+    return HttpResponse.text(`)]}'\n${JSON.stringify(mockComments)}`)
+  }),
+
+  // File diff endpoint
+  http.get('*/a/changes/:changeId/revisions/:revisionId/files/:filePath/diff', () => {
+    const mockDiff = {
+      content: [
+        {
+          ab: [
+            'function calculateTotal(items) {',
+            '  let total = 0;',
+          ],
+        },
+        {
+          b: [
+            '  // TODO: Add validation',
+            '  for (const item of items) {',
+            '    total += item.price * item.quantity;',
+            '  }',
+          ],
+        },
+        {
+          ab: [
+            '  return total;',
+            '}',
+          ],
+        },
+      ],
+    }
+
+    return HttpResponse.text(`)]}'\n${JSON.stringify(mockDiff)}`)
+  }),
+]
+
+export const emptyCommentsHandlers = [
+  http.get('*/a/changes/:changeId/revisions/:revisionId/comments', () => {
+    return HttpResponse.text(`)]}'\n{}`)
+  }),
+]


### PR DESCRIPTION
## Summary
- Add new `ger comments` command to display all comments on a Gerrit change with diff context
- Support both human-readable (default) and XML (--xml) output formats for LLM consumption
- Fix TypeScript 'any' types across all command files for improved type safety

## Changes
- **New command**: `ger comments <change-id>` displays all comments with:
  - Author, timestamp, and resolution status
  - 2 lines of diff context before/after each comment
  - Grouped by file for easy scanning
- **XML output**: `--xml` flag produces structured XML with CDATA wrapping for safe LLM consumption
- **Type safety**: Replaced all `any` error types with proper `ApiError | ConfigError | Error` unions
- **Testing**: Added comprehensive tests using MSW for proper HTTP mocking

## Usage
```bash
# Pretty format for humans
ger comments 12345

# XML format for LLMs
ger comments 12345 --xml
```

## Test plan
- [x] Unit tests added with MSW mocking
- [x] TypeScript compilation passes
- [x] Linter issues resolved
- [ ] Manual testing with real Gerrit instance

🤖 Generated with [Claude Code](https://claude.ai/code)