### PR TITLE
feat: add incoming command and enhance comment functionality

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@effect/platform": "^0.90.6",
         "@effect/platform-node": "^0.94.2",
         "@effect/schema": "^0.75.5",
+        "cli-table3": "^0.6.5",
         "commander": "^14.0.0",
         "effect": "^3.17.8",
         "ink": "^6.2.2",
@@ -74,6 +75,8 @@
     "@bundled-es-modules/statuses": ["@bundled-es-modules/statuses@1.0.1", "", { "dependencies": { "statuses": "^2.0.1" } }, "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg=="],
 
     "@bundled-es-modules/tough-cookie": ["@bundled-es-modules/tough-cookie@0.1.6", "", { "dependencies": { "@types/tough-cookie": "^4.0.5", "tough-cookie": "^4.1.4" } }, "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "@effect/cluster": ["@effect/cluster@0.46.4", "", { "peerDependencies": { "@effect/platform": "^0.90.0", "@effect/rpc": "^0.68.3", "@effect/sql": "^0.44.1", "@effect/workflow": "^0.8.3", "effect": "^3.17.6" } }, "sha512-81nWw5ABtRZZFmQTrWvfsUnqTg9LybIFYvmsiIL7xQ2t+g6746IZe9Tcv9bSmMdioJLgeuO4CiRg0FfDP2qCWA=="],
 
@@ -199,7 +202,7 @@
 
     "ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
 
-    "ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
@@ -234,6 +237,8 @@
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
 
     "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
@@ -283,7 +288,7 @@
 
     "effect": ["effect@3.17.9", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-Nkkn9n1zhy30Dq0MpQatDCH7nfYnOIiebkOHNxmmvoVnEDKCto+2ZwDDWFGzcN/ojwfqjRXWGC9Lo91K5kwZCg=="],
 
-    "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -369,7 +374,7 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -545,9 +550,9 @@
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-eof": ["strip-eof@1.0.0", "", {}, "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q=="],
 
@@ -597,6 +602,8 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
+    "@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
+
     "@babel/code-frame/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@babel/template/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
@@ -615,15 +622,21 @@
 
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
+    "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "cliui/string-width": ["string-width@2.1.1", "", { "dependencies": { "is-fullwidth-code-point": "^2.0.0", "strip-ansi": "^4.0.0" } }, "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="],
 
     "cliui/strip-ansi": ["strip-ansi@4.0.0", "", { "dependencies": { "ansi-regex": "^3.0.0" } }, "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@2.1.0", "", { "dependencies": { "string-width": "^1.0.1", "strip-ansi": "^3.0.1" } }, "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw=="],
 
+    "ink/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "ink/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "log-update/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "msw/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -632,6 +645,14 @@
     "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "os-locale/mem": ["mem@1.1.0", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-nOBDrc/wgpkd3X/JOhMqYR+/eLqlfLP4oQfoBA6QExIxEl+GU01oyEkwWyueyO8110pUKijtiHGhEmYoOn88oQ=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "yargs/string-width": ["string-width@2.1.1", "", { "dependencies": { "is-fullwidth-code-point": "^2.0.0", "strip-ansi": "^4.0.0" } }, "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="],
 
@@ -647,11 +668,11 @@
 
     "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
 
@@ -661,17 +682,29 @@
 
     "cliui/wrap-ansi/strip-ansi": ["strip-ansi@3.0.1", "", { "dependencies": { "ansi-regex": "^2.0.0" } }, "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg=="],
 
+    "ink/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+
+    "ink/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "msw/yargs/get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "msw/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "msw/yargs/y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "msw/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "widest-line/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
 
@@ -679,39 +712,27 @@
 
     "@inquirer/core/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "@inquirer/core/wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "cliui/wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@1.0.0", "", { "dependencies": { "number-is-nan": "^1.0.0" } }, "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw=="],
 
     "cliui/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
+    "ink/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
     "log-update/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "msw/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "msw/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "msw/yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "msw/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
 
     "@inquirer/core/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "msw/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "msw/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "msw/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "msw/yargs/cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@effect/platform": "^0.90.6",
     "@effect/platform-node": "^0.94.2",
     "@effect/schema": "^0.75.5",
+    "cli-table3": "^0.6.5",
     "commander": "^14.0.0",
     "effect": "^3.17.8",
     "ink": "^6.2.2",

--- a/src/cli/commands/incoming.ts
+++ b/src/cli/commands/incoming.ts
@@ -1,0 +1,111 @@
+import { Effect } from 'effect'
+import { ApiError, GerritApiService } from '@/api/gerrit'
+import { colors } from '@/utils/formatters'
+const Table = require('cli-table3')
+
+interface IncomingOptions {
+  xml?: boolean
+}
+
+export const incomingCommand = (
+  options: IncomingOptions,
+): Effect.Effect<void, ApiError, GerritApiService> =>
+  Effect.gen(function* () {
+    const gerritApi = yield* GerritApiService
+
+    // Query for changes where user is a reviewer but not the owner
+    const changes = yield* gerritApi.listChanges(
+      'is:open -owner:self -is:wip -is:ignored reviewer:self'
+    )
+
+    if (options.xml) {
+      console.log(`<?xml version="1.0" encoding="UTF-8"?>`)
+      console.log(`<incoming_result>`)
+      console.log(`  <status>success</status>`)
+      console.log(`  <count>${changes.length}</count>`)
+      console.log(`  <changes>`)
+
+      for (const change of changes) {
+        console.log(`    <change>`)
+        console.log(`      <number>${change._number}</number>`)
+        console.log(`      <subject><![CDATA[${change.subject}]]></subject>`)
+        console.log(`      <project>${change.project}</project>`)
+        console.log(`      <branch>${change.branch}</branch>`)
+        console.log(`      <status>${change.status}</status>`)
+        console.log(`      <change_id>${change.change_id}</change_id>`)
+        if (change.owner?.name) {
+          console.log(`      <owner>${change.owner.name}</owner>`)
+        }
+        if (change.updated) {
+          console.log(`      <updated>${change.updated}</updated>`)
+        }
+        console.log(`    </change>`)
+      }
+
+      console.log(`  </changes>`)
+      console.log(`</incoming_result>`)
+    } else {
+      // Human-readable output
+      if (changes.length === 0) {
+        console.log('No incoming changes for review')
+        return
+      }
+
+      console.log(`${colors.bold}Incoming changes for review:${colors.reset}\n`)
+
+      // Group changes by project
+      const changesByProject = changes.reduce((acc, change) => {
+        if (!acc[change.project]) {
+          acc[change.project] = []
+        }
+        acc[change.project] = [...acc[change.project], change]
+        return acc
+      }, {} as Record<string, typeof changes>)
+
+      // Sort projects alphabetically
+      const sortedProjects = Object.keys(changesByProject).sort()
+
+      for (const project of sortedProjects) {
+        console.log(`${colors.blue}${project}${colors.reset}`)
+        
+        const table = new Table({
+          head: [],
+          chars: {
+            'top': '', 'top-mid': '', 'top-left': '', 'top-right': '',
+            'bottom': '', 'bottom-mid': '', 'bottom-left': '', 'bottom-right': '',
+            'left': '', 'left-mid': '', 'mid': '', 'mid-mid': '',
+            'right': '', 'right-mid': '', 'middle': ' '
+          },
+          style: { 'padding-left': 0, 'padding-right': 1, border: [] },
+          colWidths: [8, null, null], // status (fixed), number (auto), subject (auto)
+        })
+
+        const projectChanges = changesByProject[project]
+        for (const change of projectChanges) {
+          const ownerName = change.owner?.name || change.owner?.username || 'Unknown'
+          
+          // Build status indicators
+          const indicators: string[] = []
+          if (change.labels?.['Code-Review']) {
+            const cr = change.labels['Code-Review']
+            if (cr.approved || cr.value === 2) indicators.push('✅')
+            else if (cr.rejected || cr.value === -2) indicators.push('❌')
+            else if (cr.recommended || cr.value === 1) indicators.push('👍')
+            else if (cr.disliked || cr.value === -1) indicators.push('👎')
+          }
+          
+          const status = indicators.length > 0 ? indicators.join(' ') : '  '
+          
+          table.push([
+            status,
+            `${change._number}`,
+            `${change.subject} ${colors.dim}(by ${ownerName})${colors.reset}`
+          ])
+        }
+        
+        console.log(table.toString())
+      }
+      
+      console.log(`\n${colors.dim}Total: ${changes.length} change(s) awaiting your review${colors.reset}`)
+    }
+  })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { initCommand } from './commands/init'
 import { statusCommand } from './commands/status'
 import { diffCommand } from './commands/diff'
 import { mineCommand } from './commands/mine'
+import { incomingCommand } from './commands/incoming'
 import { workspaceCommand } from './commands/workspace'
 import { abandonCommand } from './commands/abandon'
 import { commentsCommand } from './commands/comments'
@@ -155,6 +156,34 @@ program
         console.log(`  <status>error</status>`)
         console.log(`  <error><![CDATA[${error instanceof Error ? error.message : String(error)}]]></error>`)
         console.log(`</workspace_result>`)
+      } else {
+        console.error('✗ Error:', error instanceof Error ? error.message : String(error))
+      }
+      process.exit(1)
+    }
+  })
+
+// incoming command
+program
+  .command('incoming')
+  .description('Show incoming changes for review (where you are a reviewer)')
+  .option('--xml', 'XML output for LLM consumption')
+  .action(async (options) => {
+    try {
+      const effect = incomingCommand(options).pipe(
+        Effect.provide(GerritApiServiceLive),
+        Effect.provide(ConfigServiceLive),
+      )
+      await Effect.runPromise(effect)
+    } catch (error) {
+      if (options.xml) {
+        console.log(`<?xml version="1.0" encoding="UTF-8"?>`)
+        console.log(`<incoming_result>`)
+        console.log(`  <status>error</status>`)
+        console.log(
+          `  <error><![CDATA[${error instanceof Error ? error.message : String(error)}]]></error>`,
+        )
+        console.log(`</incoming_result>`)
       } else {
         console.error('✗ Error:', error instanceof Error ? error.message : String(error))
       }

--- a/tests/comment.test.ts
+++ b/tests/comment.test.ts
@@ -1,0 +1,583 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, mock } from 'bun:test'
+import { Effect } from 'effect'
+import { commentCommand } from '@/cli/commands/comment'
+import { GerritApiServiceLive } from '@/api/gerrit'
+import { ConfigService } from '@/services/config'
+import { Layer } from 'effect'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+// Create MSW server
+const server = setupServer(
+  // Default handler for auth check
+  http.get('*/a/accounts/self', ({ request }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth || !auth.startsWith('Basic ')) {
+      return HttpResponse.text('Unauthorized', { status: 401 })
+    }
+    return HttpResponse.json({ 
+      _account_id: 1000,
+      name: 'Test User',
+      email: 'test@example.com'
+    })
+  })
+)
+
+describe('comment command', () => {
+  let mockConsoleLog: ReturnType<typeof mock>
+  let mockConsoleError: ReturnType<typeof mock>
+  let mockProcessStdin: any
+
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'bypass' })
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  beforeEach(() => {
+    server.resetHandlers()
+    
+    mockConsoleLog = mock(() => {})
+    mockConsoleError = mock(() => {})
+    console.log = mockConsoleLog
+    console.error = mockConsoleError
+
+    // Mock process.stdin for batch tests
+    mockProcessStdin = {
+      on: mock((event: string, callback: Function) => {
+        if (event === 'data') {
+          mockProcessStdin.dataCallback = callback
+        } else if (event === 'end') {
+          mockProcessStdin.endCallback = callback
+        }
+      }),
+      emit: (data: string) => {
+        if (mockProcessStdin.dataCallback) {
+          mockProcessStdin.dataCallback(data)
+        }
+        if (mockProcessStdin.endCallback) {
+          mockProcessStdin.endCallback()
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should post an overall comment', async () => {
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text(`)]}'\n{
+          "id": "test-project~main~I123abc",
+          "_number": 12345,
+          "project": "test-project",
+          "branch": "main",
+          "change_id": "I123abc",
+          "subject": "Test change",
+          "status": "NEW",
+          "created": "2024-01-15 10:00:00.000000000",
+          "updated": "2024-01-15 10:00:00.000000000"
+        }`)
+      }),
+      http.post('*/a/changes/:changeId/revisions/current/review', async ({ request }) => {
+        const body = await request.json() as any
+        expect(body.message).toBe('This is a test comment')
+        expect(body.comments).toBeUndefined()
+        return HttpResponse.json({})
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { 
+      message: 'This is a test comment' 
+    }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('✓ Comment posted successfully!')
+    expect(output).toContain('Test change')
+  })
+
+  it('should post a line-specific comment', async () => {
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text(`)]}'\n{
+          "id": "test-project~main~I123abc",
+          "_number": 12345,
+          "project": "test-project",
+          "branch": "main",
+          "change_id": "I123abc",
+          "subject": "Test change",
+          "status": "NEW",
+          "created": "2024-01-15 10:00:00.000000000",
+          "updated": "2024-01-15 10:00:00.000000000"
+        }`)
+      }),
+      http.post('*/a/changes/:changeId/revisions/current/review', async ({ request }) => {
+        const body = await request.json() as any
+        expect(body.message).toBeUndefined()
+        expect(body.comments).toBeDefined()
+        expect(body.comments['src/main.js']).toBeDefined()
+        expect(body.comments['src/main.js'][0].line).toBe(42)
+        expect(body.comments['src/main.js'][0].message).toBe('Fix this issue')
+        expect(body.comments['src/main.js'][0].unresolved).toBe(true)
+        return HttpResponse.json({})
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { 
+      message: 'Fix this issue',
+      file: 'src/main.js',
+      line: 42,
+      unresolved: true
+    }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('✓ Comment posted successfully!')
+    expect(output).toContain('File: src/main.js, Line: 42')
+    expect(output).toContain('Status: Unresolved')
+  })
+
+  it('should handle batch comments', async () => {
+    // Override process.stdin temporarily
+    const originalStdin = process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: mockProcessStdin,
+      configurable: true
+    })
+
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text(`)]}'\n{
+          "id": "test-project~main~I123abc",
+          "_number": 12345,
+          "project": "test-project",
+          "branch": "main",
+          "change_id": "I123abc",
+          "subject": "Test change",
+          "status": "NEW",
+          "created": "2024-01-15 10:00:00.000000000",
+          "updated": "2024-01-15 10:00:00.000000000"
+        }`)
+      }),
+      http.post('*/a/changes/:changeId/revisions/current/review', async ({ request }) => {
+        const body = await request.json() as any
+        expect(body.message).toBe('Overall review')
+        expect(body.comments).toBeDefined()
+        expect(body.comments['src/main.js'].length).toBe(2)
+        expect(body.comments['src/utils.js'].length).toBe(1)
+        return HttpResponse.json({})
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { batch: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    // Simulate stdin data
+    setTimeout(() => {
+      mockProcessStdin.emit(JSON.stringify({
+        message: 'Overall review',
+        comments: [
+          { file: 'src/main.js', line: 10, message: 'First comment' },
+          { file: 'src/main.js', line: 20, message: 'Second comment', unresolved: true },
+          { file: 'src/utils.js', line: 5, message: 'Utils comment' }
+        ]
+      }))
+    }, 10)
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('✓ Comment posted successfully!')
+    expect(output).toContain('Posted 3 line comment(s)')
+
+    // Restore process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      configurable: true
+    })
+  })
+
+  it('should output XML format for line comments', async () => {
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text(`)]}'\n{
+          "id": "test-project~main~I123abc",
+          "_number": 12345,
+          "project": "test-project",
+          "branch": "main",
+          "change_id": "I123abc",
+          "subject": "Test change",
+          "status": "NEW",
+          "created": "2024-01-15 10:00:00.000000000",
+          "updated": "2024-01-15 10:00:00.000000000"
+        }`)
+      }),
+      http.post('*/a/changes/:changeId/revisions/current/review', async () => {
+        return HttpResponse.json({})
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { 
+      message: 'Fix this',
+      file: 'test.js',
+      line: 10,
+      xml: true
+    }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(output).toContain('<comment_result>')
+    expect(output).toContain('<status>success</status>')
+    expect(output).toContain('<file>test.js</file>')
+    expect(output).toContain('<line>10</line>')
+    expect(output).toContain('<message><![CDATA[Fix this]]></message>')
+  })
+
+  it('should reject invalid batch JSON', async () => {
+    const originalStdin = process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: mockProcessStdin,
+      configurable: true
+    })
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { batch: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    // Simulate invalid JSON
+    setTimeout(() => {
+      mockProcessStdin.emit('not valid json')
+    }, 10)
+
+    await expect(Effect.runPromise(program)).rejects.toThrow('Invalid batch input format')
+
+    // Restore process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      configurable: true
+    })
+  })
+
+  it('should reject invalid batch schema', async () => {
+    const originalStdin = process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: mockProcessStdin,
+      configurable: true
+    })
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { batch: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    // Simulate invalid schema
+    setTimeout(() => {
+      mockProcessStdin.emit(JSON.stringify({
+        comments: [
+          { file: 'src/main.js' } // Missing required fields
+        ]
+      }))
+    }, 10)
+
+    await expect(Effect.runPromise(program)).rejects.toThrow('Invalid batch input format')
+
+    // Restore process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      configurable: true
+    })
+  })
+
+  it('should require message for line comments', async () => {
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { 
+      file: 'test.js',
+      line: 10
+      // Missing message
+    }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await expect(Effect.runPromise(program)).rejects.toThrow('Message is required for line comments')
+  })
+
+  it('should require message for overall comments', async () => {
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', {}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await expect(Effect.runPromise(program)).rejects.toThrow('Message is required. Use -m "your message"')
+  })
+
+  it('should handle API errors gracefully', async () => {
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text('Not found', { status: 404 })
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { 
+      message: 'Test comment'
+    }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await expect(Effect.runPromise(program)).rejects.toThrow('Failed to get change')
+  })
+
+  it('should handle post review API errors', async () => {
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text(`)]}'\n{
+          "id": "test-project~main~I123abc",
+          "_number": 12345,
+          "project": "test-project",
+          "branch": "main",
+          "change_id": "I123abc",
+          "subject": "Test change",
+          "status": "NEW",
+          "created": "2024-01-15 10:00:00.000000000",
+          "updated": "2024-01-15 10:00:00.000000000"
+        }`)
+      }),
+      http.post('*/a/changes/:changeId/revisions/current/review', () => {
+        return HttpResponse.text('Forbidden', { status: 403 })
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { 
+      message: 'Test comment'
+    }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await expect(Effect.runPromise(program)).rejects.toThrow('Failed to post comment')
+  })
+
+  it('should output XML for batch comments', async () => {
+    const originalStdin = process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: mockProcessStdin,
+      configurable: true
+    })
+
+    server.use(
+      http.get('*/a/changes/:changeId', () => {
+        return HttpResponse.text(`)]}'\n{
+          "id": "test-project~main~I123abc",
+          "_number": 12345,
+          "project": "test-project",
+          "branch": "main",
+          "change_id": "I123abc",
+          "subject": "Test change",
+          "status": "NEW",
+          "created": "2024-01-15 10:00:00.000000000",
+          "updated": "2024-01-15 10:00:00.000000000"
+        }`)
+      }),
+      http.post('*/a/changes/:changeId/revisions/current/review', async () => {
+        return HttpResponse.json({})
+      })
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      })
+    )
+
+    const program = commentCommand('12345', { batch: true, xml: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    // Simulate stdin data
+    setTimeout(() => {
+      mockProcessStdin.emit(JSON.stringify({
+        message: 'Overall review',
+        comments: [
+          { file: 'src/main.js', line: 10, message: 'First comment' },
+          { file: 'src/main.js', line: 20, message: 'Second comment', unresolved: true }
+        ]
+      }))
+    }, 10)
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n')
+    expect(output).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(output).toContain('<comments>')
+    expect(output).toContain('<file>src/main.js</file>')
+    expect(output).toContain('<line>10</line>')
+    expect(output).toContain('<line>20</line>')
+    expect(output).toContain('<unresolved>true</unresolved>')
+    expect(output).toContain('</comments>')
+
+    // Restore process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      configurable: true
+    })
+  })
+})

--- a/tests/incoming.test.ts
+++ b/tests/incoming.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach, mock } from 'bun:test'
+import { Effect } from 'effect'
+import { incomingCommand } from '@/cli/commands/incoming'
+import { GerritApiServiceLive } from '@/api/gerrit'
+import { ConfigService } from '@/services/config'
+import { Layer } from 'effect'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+// Create MSW server
+const server = setupServer(
+  // Default handler for auth check
+  http.get('*/a/accounts/self', ({ request }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth || !auth.startsWith('Basic ')) {
+      return HttpResponse.text('Unauthorized', { status: 401 })
+    }
+    return HttpResponse.json({
+      _account_id: 1000,
+      name: 'Test User',
+      email: 'test@example.com',
+    })
+  }),
+)
+
+describe('incoming command', () => {
+  let mockConsoleLog: ReturnType<typeof mock>
+  let mockConsoleError: ReturnType<typeof mock>
+
+  beforeAll(() => {
+    // Start MSW server before all tests
+    server.listen({ onUnhandledRequest: 'bypass' })
+  })
+
+  afterAll(() => {
+    // Clean up after all tests
+    server.close()
+  })
+
+  beforeEach(() => {
+    // Reset handlers to defaults before each test
+    server.resetHandlers()
+
+    mockConsoleLog = mock(() => {})
+    mockConsoleError = mock(() => {})
+    console.log = mockConsoleLog
+    console.error = mockConsoleError
+  })
+
+  afterEach(() => {
+    // Clean up after each test
+    server.resetHandlers()
+  })
+
+  it('should fetch and display incoming changes in pretty format', async () => {
+    server.use(
+      http.get('*/a/changes/', ({ request }) => {
+        const url = new URL(request.url)
+        const query = url.searchParams.get('q')
+
+        // Verify the correct query
+        if (query === 'is:open -owner:self -is:wip -is:ignored reviewer:self') {
+          return HttpResponse.text(`)]}'\n[
+            {
+              "id": "team-project~main~I123abc",
+              "_number": 1001,
+              "project": "team-project",
+              "branch": "main",
+              "subject": "Fix critical bug in authentication",
+              "status": "NEW",
+              "change_id": "I123abc",
+              "owner": {
+                "_account_id": 2001,
+                "name": "Alice Developer",
+                "email": "alice@example.com"
+              },
+              "updated": "2024-01-15 10:30:00.000000000"
+            },
+            {
+              "id": "team-project~feature%2Fnew-api~I456def",
+              "_number": 1002,
+              "project": "team-project",
+              "branch": "feature/new-api",
+              "subject": "Add new API endpoint",
+              "status": "NEW",
+              "change_id": "I456def",
+              "owner": {
+                "_account_id": 2002,
+                "name": "Bob Builder",
+                "email": "bob@example.com"
+              },
+              "updated": "2024-01-15 11:00:00.000000000"
+            },
+            {
+              "id": "another-project~main~I789ghi",
+              "_number": 1003,
+              "project": "another-project",
+              "branch": "main",
+              "subject": "Update documentation",
+              "status": "NEW",
+              "change_id": "I789ghi",
+              "owner": {
+                "_account_id": 2003,
+                "name": "Charlie Coder",
+                "email": "charlie@example.com"
+              },
+              "updated": "2024-01-15 09:00:00.000000000"
+            }
+          ]`)
+        }
+        return HttpResponse.json([])
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    // Check that changes were displayed
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join('\n')
+
+    // Check project grouping
+    expect(output).toContain('team-project')
+    expect(output).toContain('another-project')
+
+    // Check change details
+    expect(output).toContain('1001')
+    expect(output).toContain('Fix critical bug in authentication')
+    expect(output).toContain('(by Alice Developer)')
+    expect(output).toContain('1002')
+    expect(output).toContain('Add new API endpoint')
+    expect(output).toContain('(by Bob Builder)')
+    expect(output).toContain('1003')
+    expect(output).toContain('Update documentation')
+    expect(output).toContain('(by Charlie Coder)')
+  })
+
+  it('should output XML format when --xml flag is used', async () => {
+    server.use(
+      http.get('*/a/changes/', ({ request }) => {
+        const url = new URL(request.url)
+        const query = url.searchParams.get('q')
+
+        if (query === 'is:open -owner:self -is:wip -is:ignored reviewer:self') {
+          return HttpResponse.text(`)]}'\n[
+            {
+              "id": "xml-project~develop~Ixmltest",
+              "_number": 2001,
+              "project": "xml-project",
+              "branch": "develop",
+              "subject": "XML test change",
+              "status": "NEW",
+              "change_id": "Ixmltest",
+              "owner": {
+                "_account_id": 3001,
+                "name": "XML User",
+                "email": "xml@example.com"
+              },
+              "updated": "2024-01-15 14:00:00.000000000"
+            }
+          ]`)
+        }
+        return HttpResponse.json([])
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({ xml: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    // Check XML output structure
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join('\n')
+    expect(output).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(output).toContain('<incoming_result>')
+    expect(output).toContain('<status>success</status>')
+    expect(output).toContain('<count>1</count>')
+    expect(output).toContain('<changes>')
+    expect(output).toContain('<change>')
+    expect(output).toContain('<number>2001</number>')
+    expect(output).toContain('<subject><![CDATA[XML test change]]></subject>')
+    expect(output).toContain('<project>xml-project</project>')
+    expect(output).toContain('<branch>develop</branch>')
+    expect(output).toContain('<status>NEW</status>')
+    expect(output).toContain('<change_id>Ixmltest</change_id>')
+    expect(output).toContain('<owner>XML User</owner>')
+    expect(output).toContain('</change>')
+    expect(output).toContain('</changes>')
+    expect(output).toContain('</incoming_result>')
+  })
+
+  it('should handle no incoming changes gracefully', async () => {
+    server.use(
+      http.get('*/a/changes/', () => {
+        return HttpResponse.text(`)]}'\n[]`)
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join('\n')
+    expect(output).toContain('No incoming changes for review')
+  })
+
+  it('should handle network failures gracefully', async () => {
+    server.use(
+      http.get('*/a/changes/', () => {
+        return HttpResponse.error()
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await expect(Effect.runPromise(program)).rejects.toThrow()
+  })
+
+  it('should handle authentication failures', async () => {
+    server.use(
+      http.get('*/a/changes/', () => {
+        return HttpResponse.text('Unauthorized', { status: 401 })
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'wrongpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await expect(Effect.runPromise(program)).rejects.toThrow()
+  })
+
+  it('should properly escape XML special characters', async () => {
+    server.use(
+      http.get('*/a/changes/', () => {
+        return HttpResponse.text(`)]}'\n[
+          {
+            "id": "test-project~main~Itest",
+            "_number": 3001,
+            "project": "test<>&\\"project",
+            "branch": "main",
+            "subject": "Fix <script>alert('XSS')</script> & entities",
+            "status": "NEW",
+            "change_id": "I<>&test",
+            "owner": {
+              "_account_id": 4001,
+              "name": "User <>&\\"'",
+              "email": "test@example.com"
+            }
+          }
+        ]`)
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({ xml: true }).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join('\n')
+    // Subject should be in CDATA
+    expect(output).toContain(
+      "<subject><![CDATA[Fix <script>alert('XSS')</script> & entities]]></subject>",
+    )
+    // Owner name should be preserved in output
+    expect(output).toContain('<owner>User <>&"\'</owner>')
+    // Project and change_id should be in output
+    expect(output).toContain('<project>test<>&"project</project>')
+    expect(output).toContain('<change_id>I<>&test</change_id>')
+  })
+
+  it('should group changes by project alphabetically', async () => {
+    server.use(
+      http.get('*/a/changes/', () => {
+        return HttpResponse.text(`)]}'\n[
+          {
+            "id": "zebra-project~main~Izebra",
+            "_number": 4001,
+            "project": "zebra-project",
+            "branch": "main",
+            "subject": "Change in zebra",
+            "status": "NEW",
+            "change_id": "Izebra",
+            "owner": {"_account_id": 5001, "name": "Zoe"}
+          },
+          {
+            "id": "alpha-project~main~Ialpha",
+            "_number": 4002,
+            "project": "alpha-project",
+            "branch": "main",
+            "subject": "Change in alpha",
+            "status": "NEW",
+            "change_id": "Ialpha",
+            "owner": {"_account_id": 5002, "name": "Amy"}
+          },
+          {
+            "id": "beta-project~main~Ibeta",
+            "_number": 4003,
+            "project": "beta-project",
+            "branch": "main",
+            "subject": "Change in beta",
+            "status": "NEW",
+            "change_id": "Ibeta",
+            "owner": {"_account_id": 5003, "name": "Ben"}
+          }
+        ]`)
+      }),
+    )
+
+    const mockConfigLayer = Layer.succeed(
+      ConfigService,
+      ConfigService.of({
+        getCredentials: Effect.succeed({
+          host: 'https://gerrit.example.com',
+          username: 'testuser',
+          password: 'testpass',
+        }),
+        saveCredentials: () => Effect.succeed(undefined),
+        deleteCredentials: Effect.succeed(undefined),
+      }),
+    )
+
+    const program = incomingCommand({}).pipe(
+      Effect.provide(GerritApiServiceLive),
+      Effect.provide(mockConfigLayer),
+    )
+
+    await Effect.runPromise(program)
+
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join('\n')
+
+    // Find positions of project names in output
+    const alphaPos = output.indexOf('alpha-project')
+    const betaPos = output.indexOf('beta-project')
+    const zebraPos = output.indexOf('zebra-project')
+
+    // Verify alphabetical order
+    expect(alphaPos).toBeLessThan(betaPos)
+    expect(betaPos).toBeLessThan(zebraPos)
+  })
+})


### PR DESCRIPTION
## Summary
- Add `ger incoming` command to show changes where user is a reviewer (not owner)
- Enhance `comment` command with line-specific and batch comment support for LLM usage
- Refactor comment.ts to use more idiomatic Effect.js patterns with better error handling

## Changes
### New Features
- **incoming command**: Shows changes where you're a reviewer but not the owner
  - Query: `is:open -owner:self -is:wip -is:ignored reviewer:self`
  - Displays owner name for each change
  - Uses cli-table3 for proper column alignment
  
- **Enhanced comment command**: Now supports line-specific comments
  - `--file` and `--line` options for targeting specific lines
  - `--unresolved` flag to mark comments requiring human attention
  - `--batch` mode to post multiple comments from JSON stdin
  - Comprehensive schema validation for batch input

### Breaking Changes
- `ger diff` now outputs pretty format by default (use `--xml` for XML output)

### Technical Improvements
- Refactored comment.ts with idiomatic Effect.js patterns
- Added comprehensive test coverage (>80% overall)
- Improved CLI help text with clear examples
- Fixed column alignment issues in change lists

## Test Plan
- [x] All existing tests pass
- [x] New tests added for incoming command
- [x] New tests added for comment enhancements
- [x] Test coverage >80% (currently 81.53%)
- [x] Manual testing of all commands

🤖 Generated with [Claude Code](https://claude.ai/code)