### PR TITLE
fix: add missing CLI options for enhanced comment command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -60,7 +60,31 @@ program
   .command('comment <change-id>')
   .description('Post a comment on a change')
   .option('-m, --message <message>', 'Comment message')
+  .option('--file <file>', 'File path for line-specific comment (relative to repo root)')
+  .option('--line <line>', 'Line number in the NEW version of the file (not diff line numbers)', parseInt)
+  .option('--unresolved', 'Mark comment as unresolved (requires human attention)')
+  .option('--batch', 'Read batch comments from stdin as JSON (see examples below)')
   .option('--xml', 'XML output for LLM consumption')
+  .addHelpText('after', `
+Examples:
+  # Post a general comment on a change
+  $ ger comment 12345 -m "Looks good to me!"
+
+  # Post a line-specific comment (line number from NEW file version)
+  $ ger comment 12345 --file src/main.js --line 42 -m "Consider using const here"
+
+  # Post an unresolved comment requiring human attention
+  $ ger comment 12345 --file src/api.js --line 15 -m "Security concern" --unresolved
+
+  # Post multiple comments using batch mode
+  $ echo '{"message": "Review complete", "comments": [
+      {"file": "src/main.js", "line": 10, "message": "Good refactor"},
+      {"file": "src/api.js", "line": 25, "message": "Check error handling", "unresolved": true}
+    ]}' | ger comment 12345 --batch
+
+Note: Line numbers refer to the actual line numbers in the NEW version of the file,
+      NOT the line numbers shown in the diff view. To find the correct line number,
+      look at the file after all changes have been applied.`)
   .action(async (changeId, options) => {
     try {
       const effect = commentCommand(changeId, options).pipe(


### PR DESCRIPTION
## Summary
The comment command's enhanced options (--file, --line, --unresolved, --batch) were implemented in the command logic but not exposed in the CLI interface. This PR adds the missing options and help text.

## Problem
After merging PR #6, the following issues were discovered:
- `ger incoming` command was not available (binary not rebuilt)
- `ger comment` was missing the new CLI options despite having the implementation

## Solution
- Added missing CLI option definitions for the comment command
- Added comprehensive help text with examples
- Rebuilt the binary to include all changes

## Test Plan
- [x] All tests pass (105 passing, 0 failing)
- [x] Coverage remains >80% (81.53%)
- [x] `ger incoming` command works
- [x] `ger comment --help` shows all new options
- [x] Line-specific comments work with --file and --line
- [x] Batch mode works with --batch

🤖 Generated with [Claude Code](https://claude.ai/code)