### PR TITLE
Fix: Remove extra whitespace from incoming command output

### DIFF
--- a/src/cli/commands/incoming.ts
+++ b/src/cli/commands/incoming.ts
@@ -64,8 +64,11 @@ export const incomingCommand = (
       // Sort projects alphabetically
       const sortedProjects = Object.keys(changesByProject).sort()
 
-      for (const project of sortedProjects) {
-        console.log(`\n${colors.blue}${project}${colors.reset}`)
+      for (const [index, project] of sortedProjects.entries()) {
+        if (index > 0) {
+          console.log('') // Add blank line between projects
+        }
+        console.log(`${colors.blue}${project}${colors.reset}`)
 
         const projectChanges = changesByProject[project]
         for (const change of projectChanges) {


### PR DESCRIPTION
## Summary
- Remove leading newline before first project name  
- Only add blank lines between projects, not before the first one
- Results in cleaner output without unwanted pre/post spacing

## Before
```
<blank line>
canvas-lms
...
```

## After  
```
canvas-lms
...
```

The command now outputs a clean list starting immediately with the first project name, with proper spacing only between multiple projects.