### PR TITLE
Update mine command output to match incoming format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@
 - **RUN** type-checking in pre-commit and pre-push hooks
 - **RUN** oxlint in pre-commit and pre-push hooks
 - **RUN** biome formatter before commits
+- **RUN** `bun run build` after making changes to ensure compilation succeeds
 - **USE** ast-grep to enforce no `as` typecasting rule
 - **CHECK** file sizes in pre-commit and pre-push hooks
 - **EXCLUDE** generated code and tmp/ from all checks


### PR DESCRIPTION
## Summary
Updates the `ger mine` command output to match the clean format used by `ger incoming`:

- **Same status indicators**: Uses ✅, 👍, ❌ with proper 8-space padding
- **Single line format**: `{status} {change_number} {subject}` 
- **No author**: Removes author name since it's redundant for user's own changes
- **Clean spacing**: Proper blank lines between projects, no leading whitespace
- **Silent empty results**: No message when no changes found
- **Removes extra info**: No separate lines for branch/date for cleaner output

## Before
```
project-name
  ✅ 12345: Fix important bug
    branch: feature-branch
    2024-01-15 10:30:00
```

## After  
```
project-name
✅        12345  Fix important bug
```

This provides consistent formatting across both commands while keeping the mine-specific behavior (no author names).