### PR TITLE
feat: support piped input for comment command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,6 +72,10 @@ Examples:
   # Post a general comment on a change
   $ ger comment 12345 -m "Looks good to me!"
 
+  # Post a comment using piped input (useful for multi-line comments or scripts)
+  $ echo "This is a comment from stdin!" | ger comment 12345
+  $ cat review-notes.txt | ger comment 12345
+
   # Post a line-specific comment (line number from NEW file version)
   $ ger comment 12345 --file src/main.js --line 42 -m "Consider using const here"
 


### PR DESCRIPTION
## Summary

This PR adds support for piped input to the `ger comment` command, enabling more flexible comment workflows and better shell integration.

## 🚀 New Functionality

You can now pipe content directly to the comment command:

```bash
# Simple piping
echo "Great work on this fix!" | ger comment 12345

# Multi-line comments from files  
cat review-notes.txt | ger comment 12345

# Integration with other commands
git log --oneline -5 | ger comment 12345
```

## 📋 Technical Details

### **Backward Compatibility**
- ✅ **Fully backward compatible** - existing `-m` flag usage unchanged
- ✅ **Maintains all existing functionality** - batch mode, line comments, XML output

### **Implementation**
- **Reads from stdin** when no `-m` message flag is provided
- **Automatic whitespace trimming** for cleaner input processing
- **Enhanced error handling** with helpful messages for empty input
- **Uses existing `readStdin` infrastructure** already used for batch mode

### **User Experience**
- **Updated help text** with piped input examples
- **Clear error messages** guide users to proper usage
- **Seamless integration** with shell workflows and scripts

## 🧪 Testing

- **2 new integration tests** covering piped input scenarios
- **Updated existing test** to handle new error message format
- **All 221 tests passing** with maintained coverage (86.98% lines)
- **Comprehensive testing** of whitespace handling and error cases

## 📝 Changes Made

### Code Changes
- **`src/cli/commands/comment.ts`**:
  - Enhanced `createReviewInput` to read from stdin when no message provided
  - Fixed output display to show actual review message for piped input
- **`src/cli/index.ts`**: 
  - Added piped input examples to help text

### Test Changes  
- **`tests/comment.test.ts`**:
  - Added test for piped input functionality
  - Added test for whitespace trimming
  - Updated error message test for new behavior

## 🔄 Usage Examples

```bash
# Traditional usage (unchanged)
ger comment 12345 -m "LGTM!"

# NEW: Piped input
echo "Looks good to me!" | ger comment 12345

# NEW: Multi-line from file
cat << EOF | ger comment 12345
This change looks great! A few observations:

1. Nice refactoring of the error handling
2. Good test coverage additions  
3. Documentation is clear and helpful

Overall LGTM! 🚀
EOF
```

This enhancement makes the tool more Unix-friendly and enables powerful comment workflows while maintaining full backward compatibility.