### PR TITLE
fix: add TTY checks for interactive commands to support non-TTY environments

### DIFF
--- a/src/cli/commands/abandon.ts
+++ b/src/cli/commands/abandon.ts
@@ -70,6 +70,13 @@ export const abandonCommand = (
     const gerritApi = yield* GerritApiService
 
     if (!changeId) {
+      // Check if we're in a TTY environment (required for interactive mode)
+      if (!process.stdin.isTTY) {
+        console.error('✗ Change ID is required when running in non-TTY environment')
+        console.error('  Usage: ger abandon <change-id>')
+        return
+      }
+
       // Interactive mode when no change ID provided
       const changes = yield* gerritApi.listChanges('owner:self status:open')
 

--- a/src/cli/commands/incoming.ts
+++ b/src/cli/commands/incoming.ts
@@ -23,6 +23,16 @@ export const incomingCommand = (
     )
 
     if (options.interactive) {
+      // Check if we're in a TTY environment (required for Ink)
+      if (!process.stdin.isTTY) {
+        console.error(`${colors.red}✗ Interactive mode requires a TTY terminal${colors.reset}`)
+        console.error(
+          `${colors.yellow}  Running from within Claude Code or piped input is not supported${colors.reset}`,
+        )
+        console.error(`${colors.yellow}  Try running without --interactive flag${colors.reset}`)
+        return
+      }
+
       // Get Gerrit host for opening changes in browser
       const configService = yield* ConfigService
       const credentials = yield* configService.getCredentials


### PR DESCRIPTION
## Summary
- Fixes Ink raw mode errors when running commands from non-TTY environments (like Claude Code)
- All commands now work properly in non-TTY mode 
- Interactive features gracefully fail with helpful error messages when TTY is required

## Changes
- Added TTY check before using Ink's `render()` in incoming command with `--interactive` flag
- Added TTY check for abandon command when no change ID provided (interactive mode)
- Show helpful error messages when TTY is required but not available

## Test plan
All commands tested in non-TTY environment (piped input):
- ✅ `echo "" | ger show 12345` - works without errors
- ✅ `echo "" | ger incoming` - displays changes list
- ✅ `echo "" | ger incoming --interactive` - shows helpful TTY error
- ✅ `echo "" | ger abandon 12345` - attempts abandon 
- ✅ `echo "" | ger abandon` - shows helpful error requiring change ID
- ✅ All other commands work in non-TTY mode

This ensures the CLI is fully functional when used from within Claude Code or other non-TTY environments, while preserving interactive features for terminal use.

🤖 Generated with [Claude Code](https://claude.ai/code)