### PR TITLE
refactor: remove Claude SDK dependency in favor of CLI-only approach

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,6 @@
     "": {
       "name": "ger",
       "dependencies": {
-        "@anthropic-ai/claude-code": "^1.0.102",
         "@effect/platform": "^0.90.6",
         "@effect/platform-node": "^0.94.2",
         "@effect/schema": "^0.75.5",
@@ -32,8 +31,6 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@1.0.102", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.33.5", "@img/sharp-darwin-x64": "^0.33.5", "@img/sharp-linux-arm": "^0.33.5", "@img/sharp-linux-arm64": "^0.33.5", "@img/sharp-linux-x64": "^0.33.5", "@img/sharp-win32-x64": "^0.33.5" }, "bin": { "claude": "cli.js" } }, "sha512-UIC6qNgKNZi1nLTf1bQvxNfd74xIAqJjIx6vggh3bJOMtuXBiFwrfPk1Pdf9CayYgwZYXgSmxYYaASt6i6ficQ=="],
-
     "@babel/code-frame": ["@babel/code-frame@7.0.0-beta.37", "", { "dependencies": { "chalk": "^2.0.0", "esutils": "^2.0.2", "js-tokens": "^3.0.0" } }, "sha512-LIpcKm+2otOOvOvhCbD6wkNYi8aUwHk73uWR+hxBdW2EFht5D0QX89n4me8nyeNGWr5zC3Pvmjq+9MvUof+jkg=="],
 
     "@babel/generator": ["@babel/generator@7.28.3", "", { "dependencies": { "@babel/parser": "^7.28.3", "@babel/types": "^7.28.2", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw=="],
@@ -95,28 +92,6 @@
     "@effect/sql": ["@effect/sql@0.44.2", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.54.6", "@effect/platform": "^0.90.4", "effect": "^3.17.7" } }, "sha512-DEcvriHvj88zu7keruH9NcHQzam7yQzLNLJO6ucDXMCAwWzYZSJOsmkxBznRFv8ylFtccSclKH2fuj+wRKPjCQ=="],
 
     "@effect/workflow": ["@effect/workflow@0.8.3", "", { "peerDependencies": { "@effect/platform": "^0.90.0", "@effect/rpc": "^0.68.3", "effect": "^3.17.6" } }, "sha512-8X5IOemCb6I66GMd84w6NSmaQ+Ya3oXwItCUMelQAEuRtGzwqsw8PNNunQgK/poSRkmpszlsKOb6kEVNjSdFiQ=="],
-
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
-
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
-
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
-
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
-
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
-
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
-
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
-
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
-
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
-
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
-
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@4.2.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.102",
     "@effect/platform": "^0.90.6",
     "@effect/platform-node": "^0.94.2",
     "@effect/schema": "^0.75.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaronshaf/ger",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "module": "index.ts",
   "type": "module",
   "bin": {

--- a/src/services/review-strategy.ts
+++ b/src/services/review-strategy.ts
@@ -5,13 +5,6 @@ import { promisify } from 'node:util'
 
 const execAsync = promisify(exec)
 
-// Dynamic import for Claude SDK
-const getClaudeSDK = () =>
-  Effect.tryPromise({
-    try: () => import('@anthropic-ai/claude-code'),
-    catch: () => null,
-  }).pipe(Effect.orElseSucceed(() => null))
-
 // Simple strategy focused only on review needs
 export class ReviewStrategyError extends Data.TaggedError('ReviewStrategyError')<{
   message: string
@@ -233,62 +226,6 @@ export const codexCliStrategy: ReviewStrategy = {
     }),
 }
 
-export const claudeSDKStrategy: ReviewStrategy = {
-  name: 'Claude SDK',
-  isAvailable: () =>
-    Effect.gen(function* () {
-      const sdk = yield* getClaudeSDK()
-
-      // Check if we have ANTHROPIC_API_KEY
-      const hasApiKey = Boolean(process.env.ANTHROPIC_API_KEY)
-
-      return Boolean(sdk && hasApiKey)
-    }),
-  executeReview: (prompt, options = {}) =>
-    Effect.gen(function* () {
-      const sdk = yield* getClaudeSDK()
-
-      if (!sdk) {
-        return yield* Effect.fail(
-          new ReviewStrategyError({
-            message: 'Claude SDK not available',
-          }),
-        )
-      }
-
-      const result = yield* Effect.tryPromise({
-        try: async () => {
-          const messages = []
-
-          for await (const message of sdk.query({
-            prompt,
-            options: {
-              maxTurns: 3,
-              customSystemPrompt:
-                options.systemPrompt ||
-                'You are a code review expert. Analyze code changes and provide constructive feedback.',
-              allowedTools: ['Read', 'Grep', 'Glob'],
-              cwd: options.cwd,
-            },
-          })) {
-            if (message.type === 'result' && message.subtype === 'success') {
-              return message.result
-            }
-          }
-
-          throw new Error('No result received from Claude SDK')
-        },
-        catch: (error) =>
-          new ReviewStrategyError({
-            message: `Claude SDK failed: ${error instanceof Error ? error.message : String(error)}`,
-            cause: error,
-          }),
-      })
-
-      return result
-    }),
-}
-
 // Review service using strategy pattern
 export class ReviewStrategyService extends Context.Tag('ReviewStrategyService')<
   ReviewStrategyService,
@@ -311,7 +248,6 @@ export const ReviewStrategyServiceLive = Layer.succeed(
     getAvailableStrategies: () =>
       Effect.gen(function* () {
         const strategies = [
-          claudeSDKStrategy,
           claudeCliStrategy,
           geminiCliStrategy,
           openCodeCliStrategy,
@@ -332,7 +268,6 @@ export const ReviewStrategyServiceLive = Layer.succeed(
     selectStrategy: (preferredName?: string) =>
       Effect.gen(function* () {
         const strategies = [
-          claudeSDKStrategy,
           claudeCliStrategy,
           geminiCliStrategy,
           openCodeCliStrategy,


### PR DESCRIPTION
## Summary
- Remove @anthropic-ai/claude-code package dependency
- Remove claudeSDKStrategy from review strategy implementations
- Keep only CLI-based strategies (claude -p, gemini, opencode, codex)

## Test plan
- [x] All existing tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Code coverage maintained at 80%+
- [x] Build process succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)