### PR TITLE
refactor: remove codex CLI support

### DIFF
--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -331,7 +331,7 @@ export const reviewCommand = (changeId: string, options: ReviewOptions = {}) =>
 
     if (availableStrategies.length === 0) {
       return yield* Effect.fail(
-        new Error('No AI tools available. Please install claude, gemini, or codex CLI.'),
+        new Error('No AI tools available. Please install claude, gemini, or opencode CLI.'),
       )
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -368,15 +368,12 @@ program
   .option('-y, --yes', 'Skip confirmation prompts when posting comments')
   .option('--debug', 'Show debug output including AI responses')
   .option('--prompt <file>', 'Path to custom review prompt file (e.g., ~/prompts/review.md)')
-  .option(
-    '--provider <provider>',
-    'Preferred AI provider (claude-sdk, claude, gemini, codex, opencode)',
-  )
+  .option('--provider <provider>', 'Preferred AI provider (claude-sdk, claude, gemini, opencode)')
   .option('--system-prompt <prompt>', 'Custom system prompt for the AI')
   .addHelpText(
     'after',
     `
-This command uses AI (Claude SDK, claude CLI, gemini CLI, codex CLI, or opencode CLI) to review a Gerrit change.
+This command uses AI (Claude SDK, claude CLI, gemini CLI, or opencode CLI) to review a Gerrit change.
 It performs a two-stage review process:
 
 1. Generates inline comments for specific code issues
@@ -387,7 +384,7 @@ Use --comment to post the review to Gerrit (with confirmation prompts).
 Use --comment --yes to post without confirmation.
 
 Requirements:
-  - One of these AI tools must be available: Claude SDK (ANTHROPIC_API_KEY), claude CLI, gemini CLI, codex CLI, or opencode CLI
+  - One of these AI tools must be available: Claude SDK (ANTHROPIC_API_KEY), claude CLI, gemini CLI, or opencode CLI
   - Gerrit credentials must be configured (run 'ger setup' first)
 
 Examples:


### PR DESCRIPTION
## Summary
• Remove codex CLI strategy and references from review command
• Delete codexCliStrategy implementation from review-strategy.ts
• Update error messages and help text to exclude codex mentions
• Clean up unused imports and maintain code quality

## Changes Made
- **src/services/review-strategy.ts**: Removed `codexCliStrategy` and updated strategy arrays
- **src/cli/index.ts**: Updated help text and provider options to exclude codex
- **src/cli/commands/review.ts**: Updated error message to exclude codex reference

## Test Plan
- [x] All existing tests pass
- [x] Build completes successfully  
- [x] Linting passes with clean code
- [x] No breaking changes to other AI providers (claude, gemini, opencode)

🤖 Generated with [Claude Code](https://claude.ai/code)